### PR TITLE
feat: make variables used in queries work

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,4 +1,4 @@
-import { getBackendSrv, BackendSrvRequest, FetchResponse } from "@grafana/runtime";
+import { getBackendSrv, getTemplateSrv, BackendSrvRequest, FetchResponse } from "@grafana/runtime";
 import {
   DataQueryRequest,
   DataQueryResponse,
@@ -58,12 +58,15 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     const end = range!.to;
 
     const calls = options.targets.map(target => {
+      const query = getTemplateSrv().replace(target.queryText, options.scopedVars);
+
       const request = {
-        "query": target.queryText,
+        "query": query,
         "startTime": start.toISOString(),
         "endTime": end.toISOString(),
         "send_null": true
       };
+
       return lastValueFrom(
         this.doFetch<any[]>({
           url: this.url + '/api/v1/query',


### PR DESCRIPTION
This changes makes it possible to use dashboard variables in queries.

![Screen Cast 2023-06-14 at 9 17 18 AM](https://github.com/parseablehq/parseable-datasource/assets/49564025/dc2845c4-61e6-45f0-b6dd-623eea19291e)

For if this PR does get approved & merged: what does the release process look like? When could we expect this change to land?