### PR TITLE
feat: show if error happens while querying

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -77,7 +77,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
             return this.arrayToDataFrame(response.data);
           }),
           catchError((err) => {
-            return of({ data: [] });
+            throw new Error(err.data.message);
           })
         )
       );


### PR DESCRIPTION
This makes it a lot easier to debug errors in queries. Previously, I had to check the response of the query by using the browser developer tools.

Now it will show the error in the UI.

![afbeelding](https://github.com/parseablehq/parseable-datasource/assets/49564025/7b71587f-c62f-455d-91b6-f49ef2b19534)
