### PR TITLE
feat: add support for dynamic variables from parseable

### DIFF
--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+interface VariableQueryProps {
+  query: string;
+  onChange: (query: string, definition: string) => void;
+}
+
+export const VariableQueryEditor = ({ onChange, query }: VariableQueryProps) => {
+  const [state, setState] = useState(query);
+
+  const saveQuery = () => {
+    onChange(state, state);
+  };
+
+  const handleChange = (event: React.FormEvent<HTMLInputElement>) =>
+    setState(event.currentTarget.value);
+
+  return (
+    <>
+      <div className="gf-form">
+        <span className="gf-form-label width-10">Query</span>
+        <input
+          name="rawQuery"
+          className="gf-form-input"
+          onBlur={saveQuery}
+          onChange={handleChange}
+          value={state}
+        />
+      </div>
+    </>
+  );
+};
+

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -8,6 +8,7 @@ import {
   DataFrame,
   FieldType,
   guessFieldTypeFromValue,
+  MetricFindValue
 } from '@grafana/data';
 import { lastValueFrom, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -87,6 +88,30 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     return {
       data,
     };
+  }
+
+  async metricFindQuery(query: string, options?: any): Promise<MetricFindValue[]> {
+    const to = new Date();
+    const from = new Date();
+    from.setFullYear(to.getFullYear() - 1);
+
+    options = options || {};
+    options.range = options.range || { 
+      from: from,
+      to: to
+    }
+
+    options.targets = [];
+    options.targets.push({ queryText: query, scopedVars: {} });
+
+    const response = await this.query(options);
+
+    return response.data.map((dataFrame) => {
+      return dataFrame.fields[0].values.toArray();
+    }
+    ).flat().map((value) => {
+      return { text: value };
+    });
   }
 
   arrayToDataFrame(array: any[]): DataFrame {

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,8 +2,10 @@ import { DataSourcePlugin } from '@grafana/data';
 import { DataSource } from './datasource';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
+import { VariableQueryEditor } from './components/VariableQueryEditor';
 import { MyQuery, MyDataSourceOptions } from './types';
 
 export const plugin = new DataSourcePlugin<DataSource, MyQuery, MyDataSourceOptions>(DataSource)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditor(QueryEditor);
+  .setQueryEditor(QueryEditor)
+  .setVariableQueryEditor(VariableQueryEditor);


### PR DESCRIPTION
This makes it possible to query Parseable for Grafana dashboard variables. This is useful for dynamically retrieving application names, response codes, etc.

![image](https://github.com/parseablehq/parseable-datasource/assets/49564025/fedbb600-7f4f-4fd4-ba8b-2925a891d040)
