### PR TITLE
feat: handle query interpolation multi-valued variable

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -91,7 +91,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
 
   private formatter(value: string | string[], options: any): string {
     if (options.multi) {
-      return value.map(v => `'${v}'`).join(',');
+      return (value as string[]).map(v => `'${v}'`).join(',');
     }
     return value as string;
   }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -95,6 +95,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
       return (value as string[]).map(v => `'${v}'`).join(',');
     }
     return value as string;
+  }
 
   async metricFindQuery(query: string, options?: any): Promise<MetricFindValue[]> {
     const to = new Date();

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -93,7 +93,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     if (options.multi) {
       return value.map(v => `'${v}'`).join(',');
     }
-    return value;
+    return value as string;
   }
 
   arrayToDataFrame(array: any[]): DataFrame {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -58,7 +58,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     const end = range!.to;
 
     const calls = options.targets.map(target => {
-      const query = getTemplateSrv().replace(target.queryText, options.scopedVars);
+      const query = getTemplateSrv().replace(target.queryText, options.scopedVars, this.formatter);
 
       const request = {
         "query": query,
@@ -87,6 +87,13 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     return {
       data,
     };
+  }
+
+  private formatter(value: string | string[], options: any): string {
+    if (options.multi) {
+      return value.map(v => `'${v}'`).join(',');
+    }
+    return value;
   }
 
   arrayToDataFrame(array: any[]): DataFrame {


### PR DESCRIPTION
This is a follow up for the previous PR. This makes it possible to query with both single- and multi-valued variables. 

After this PR, the following query in Grafana:
```sql
SELECT * FROM backend WHERE application_name IN ($application) OR duration_ms IN ($duration) OR sub = '$sub'
```

In to:
```sql
SELECT * FROM backend WHERE application_name IN ('Elfskot.Api','Elfsquad.ConfiguratorApi','Elfsquad.OdataApi') OR duration_ms IN ('30', '8') OR sub = '1ff96bd8-53d8-4214-85b9-08da00dc987f'
```

The `WHERE IN (x, y, z)` with single quotes seems to work for both numbers & strings. The logic in the formatter might need to be improved for more complex data types.