### PR TITLE
fix: handle invalid initial value in variable formatter

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -91,8 +91,10 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
   }
 
   private formatter(value: string | string[], options: any): string {
-    if (options.multi) {
+    if (options.multi && Array.isArray(value)) {
       return (value as string[]).map(v => `'${v}'`).join(',');
+    } else if (options.multi) {
+      return `'${value}'`;
     }
     return value as string;
   }


### PR DESCRIPTION
There seems to be an issue present in older versions of Grafana, where a wrong initial value is sent. This handles that edge case.

https://github.com/parseablehq/parseable-datasource/assets/49564025/8ef3dd77-88ba-48ef-be37-f0210db64016

